### PR TITLE
Make /pong family-friendly

### DIFF
--- a/src/main/java/com/sk89q/commandbook/FunComponent.java
+++ b/src/main/java/com/sk89q/commandbook/FunComponent.java
@@ -246,8 +246,7 @@ public class FunComponent extends BukkitComponent {
         @CommandPermissions({"commandbook.pong"})
         public void pong(CommandContext args, CommandSender sender) throws CommandException {
 
-            sender.sendMessage(ChatColor.YELLOW +
-                    "I hear " + ChatUtil.toColoredName(sender, ChatColor.YELLOW) + " likes cute Asian boys.");
+            sender.sendMessage(ChatColor.YELLOW + "Ping!");
         }
 
         @Command(aliases = {"spawnmob"}, usage = "<mob>[|rider] [count] [location]", desc = "Spawn a mob",


### PR DESCRIPTION
Previous output of "/pong" was not safe for work; I've made it safe.


I had some parents complain very loudly after their kids got curious and used /pong on my server. I've since aliased it to /ping, but for future server owners who might not know the output of the command upon installing the plugin, it might be good for it to be "safe for work".