### PR TITLE
Kit multi enchant

### DIFF
--- a/src/main/java/com/sk89q/commandbook/kits/FlatFileKitsManager.java
+++ b/src/main/java/com/sk89q/commandbook/kits/FlatFileKitsManager.java
@@ -100,7 +100,7 @@ public class FlatFileKitsManager implements KitManager {
                     continue;
                 }
 
-                String[] parts = line.split(",");
+                String[] parts = line.split("+");
                 ItemStack item = ItemUtil.getItem(parts[0].replace(" ", ""));
 
                 if (item == null) {

--- a/src/main/java/com/sk89q/commandbook/kits/FlatFileKitsManager.java
+++ b/src/main/java/com/sk89q/commandbook/kits/FlatFileKitsManager.java
@@ -100,7 +100,7 @@ public class FlatFileKitsManager implements KitManager {
                     continue;
                 }
 
-                String[] parts = line.split("+");
+                String[] parts = line.split("-");
                 ItemStack item = ItemUtil.getItem(parts[0].replace(" ", ""));
 
                 if (item == null) {

--- a/src/main/resources/kits.txt
+++ b/src/main/resources/kits.txt
@@ -6,7 +6,7 @@
 #
 # The name of the items are names that you can use with the /item command,
 # so you can do step:wood if you want. If you want to specify an amount, enter
-# the number after a comma, like "wood,64".
+# the number after a hyphen, like "wood-64".
 #
 # If you put <name>=# for a kit, then you can choose a "cool down" period
 # in seconds. Players have to wait that amount of time before they can
@@ -16,4 +16,4 @@
 woodpick
 woodaxe
 woodshovel
-wood,64
+wood-64


### PR DESCRIPTION
Necessary to delimit the quantity of items in kits differently from how multiple enchantments are separated. Using the hyphen causes no issues with regex matching of split(), while even escaping meta characters like *,&,$ cause Cmdbook to fail loading all of its commands

Will disallow hyphenated item names

I'm not very familiar with git yet, exemplified in commits